### PR TITLE
Update bosh-notes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ BOSH Release   | [![bosh-ci.cf-app.com](https://main.bosh-ci.cf-app.com/api/v1/t
 
 * CI: <https://main.bosh-ci.cf-app.com/teams/main/pipelines/config-server>
 
-See [bosh-notes](https://github.com/cloudfoundry/bosh-notes/blob/master/config-server.md) for more information
+See [bosh-notes](https://github.com/cloudfoundry/bosh-notes/blob/master/proposals/config-server.md) for more information


### PR DESCRIPTION
Updated bosh-notes link to the correct documentation link rather than a 404.