### PR TITLE
Use code.cloudfoundry.org/config-server module path

### DIFF
--- a/src/config-server/config/config_test.go
+++ b/src/config-server/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cloudfoundry/config-server/config"
+	. "code.cloudfoundry.org/config-server/config"
 )
 
 var _ = Describe("ParseConfig", func() {

--- a/src/config-server/go.mod
+++ b/src/config-server/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudfoundry/config-server
+module code.cloudfoundry.org/config-server
 
 go 1.25.0
 

--- a/src/config-server/integration/id_test.go
+++ b/src/config-server/integration/id_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 
-	. "github.com/cloudfoundry/config-server/integration/support"
+	. "code.cloudfoundry.org/config-server/integration/support"
 )
 
 var _ = Describe("Supported HTTP Methods", func() {

--- a/src/config-server/integration/integration_tests_suite_test.go
+++ b/src/config-server/integration/integration_tests_suite_test.go
@@ -18,7 +18,7 @@ func TestIntegrationTests(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	configServerPath, err := gexec.Build("github.com/cloudfoundry/config-server")
+	configServerPath, err := gexec.Build("code.cloudfoundry.org/config-server")
 	Expect(err).NotTo(HaveOccurred())
 	return []byte(configServerPath)
 }, func(data []byte) {

--- a/src/config-server/integration/main_test.go
+++ b/src/config-server/integration/main_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 
-	. "github.com/cloudfoundry/config-server/integration/support"
+	. "code.cloudfoundry.org/config-server/integration/support"
 )
 
 var _ = Describe("Supported HTTP Methods", func() {

--- a/src/config-server/main.go
+++ b/src/config-server/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cloudfoundry/config-server/config"
-	"github.com/cloudfoundry/config-server/log"
-	"github.com/cloudfoundry/config-server/server"
+	"code.cloudfoundry.org/config-server/config"
+	"code.cloudfoundry.org/config-server/log"
+	"code.cloudfoundry.org/config-server/server"
 )
 
 func main() {

--- a/src/config-server/server/authentication_handler_test.go
+++ b/src/config-server/server/authentication_handler_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	. "github.com/cloudfoundry/config-server/server"
-	. "github.com/cloudfoundry/config-server/server/serverfakes"
+	. "code.cloudfoundry.org/config-server/server"
+	. "code.cloudfoundry.org/config-server/server/serverfakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/server/error_response_test.go
+++ b/src/config-server/server/error_response_test.go
@@ -1,7 +1,7 @@
 package server_test
 
 import (
-	. "github.com/cloudfoundry/config-server/server"
+	. "code.cloudfoundry.org/config-server/server"
 
 	"errors"
 

--- a/src/config-server/server/request_handler.go
+++ b/src/config-server/server/request_handler.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/cloudfoundry/bosh-utils/errors"
 
-	"github.com/cloudfoundry/config-server/store"
-	"github.com/cloudfoundry/config-server/types"
+	"code.cloudfoundry.org/config-server/store"
+	"code.cloudfoundry.org/config-server/types"
 )
 
 type requestHandler struct {

--- a/src/config-server/server/request_handler_test.go
+++ b/src/config-server/server/request_handler_test.go
@@ -11,11 +11,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cloudfoundry/config-server/server"
-	"github.com/cloudfoundry/config-server/store"
-	. "github.com/cloudfoundry/config-server/store/storefakes"
-	"github.com/cloudfoundry/config-server/types"
-	. "github.com/cloudfoundry/config-server/types/typesfakes"
+	. "code.cloudfoundry.org/config-server/server"
+	"code.cloudfoundry.org/config-server/store"
+	. "code.cloudfoundry.org/config-server/store/storefakes"
+	"code.cloudfoundry.org/config-server/types"
+	. "code.cloudfoundry.org/config-server/types/typesfakes"
 )
 
 func generateHTTPRequest(method, urlStr string, body io.Reader) (*http.Request, error) {

--- a/src/config-server/server/server_concrete.go
+++ b/src/config-server/server/server_concrete.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/cloudfoundry/config-server/config"
-	"github.com/cloudfoundry/config-server/store"
-	"github.com/cloudfoundry/config-server/types"
+	"code.cloudfoundry.org/config-server/config"
+	"code.cloudfoundry.org/config-server/store"
+	"code.cloudfoundry.org/config-server/types"
 
 	"github.com/cloudfoundry/bosh-utils/errors"
 )

--- a/src/config-server/server/serverfakes/fake_token_validator.go
+++ b/src/config-server/server/serverfakes/fake_token_validator.go
@@ -4,7 +4,7 @@ package serverfakes
 import (
 	"sync"
 
-	"github.com/cloudfoundry/config-server/server"
+	"code.cloudfoundry.org/config-server/server"
 )
 
 type FakeTokenValidator struct {

--- a/src/config-server/server/token_validator_jwt_test.go
+++ b/src/config-server/server/token_validator_jwt_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cloudfoundry/config-server/server"
+	. "code.cloudfoundry.org/config-server/server"
 )
 
 var _ = Describe("JwtTokenValidator", func() {

--- a/src/config-server/server/x509_loader.go
+++ b/src/config-server/server/x509_loader.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/cloudfoundry/bosh-utils/errors"
 
-	"github.com/cloudfoundry/config-server/store"
-	"github.com/cloudfoundry/config-server/types"
+	"code.cloudfoundry.org/config-server/store"
+	"code.cloudfoundry.org/config-server/types"
 )
 
 type x509Loader struct {

--- a/src/config-server/server/x509_loader_test.go
+++ b/src/config-server/server/x509_loader_test.go
@@ -8,10 +8,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/cloudfoundry/config-server/server"
-	"github.com/cloudfoundry/config-server/store"
-	. "github.com/cloudfoundry/config-server/store/storefakes"
-	"github.com/cloudfoundry/config-server/types"
+	"code.cloudfoundry.org/config-server/server"
+	"code.cloudfoundry.org/config-server/store"
+	. "code.cloudfoundry.org/config-server/store/storefakes"
+	"code.cloudfoundry.org/config-server/types"
 )
 
 var _ = Describe("x509Loader", func() {

--- a/src/config-server/store/configuration_test.go
+++ b/src/config-server/store/configuration_test.go
@@ -1,7 +1,7 @@
 package store_test
 
 import (
-	"github.com/cloudfoundry/config-server/store"
+	"code.cloudfoundry.org/config-server/store"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/store/db_provider_concrete.go
+++ b/src/config-server/store/db_provider_concrete.go
@@ -14,8 +14,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/cloudfoundry/config-server/config"
-	"github.com/cloudfoundry/config-server/store/db_migrations"
+	"code.cloudfoundry.org/config-server/config"
+	"code.cloudfoundry.org/config-server/store/db_migrations"
 )
 
 type concreteDbProvider struct {

--- a/src/config-server/store/db_provider_concrete_test.go
+++ b/src/config-server/store/db_provider_concrete_test.go
@@ -1,9 +1,9 @@
 package store_test
 
 import (
-	"github.com/cloudfoundry/config-server/config"
-	. "github.com/cloudfoundry/config-server/store"
-	fakes "github.com/cloudfoundry/config-server/store/storefakes"
+	"code.cloudfoundry.org/config-server/config"
+	. "code.cloudfoundry.org/config-server/store"
+	fakes "code.cloudfoundry.org/config-server/store/storefakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/store/store_factory.go
+++ b/src/config-server/store/store_factory.go
@@ -3,7 +3,7 @@ package store
 import (
 	"strings"
 
-	"github.com/cloudfoundry/config-server/config"
+	"code.cloudfoundry.org/config-server/config"
 
 	"github.com/cloudfoundry/bosh-utils/errors"
 )

--- a/src/config-server/store/store_factory_test.go
+++ b/src/config-server/store/store_factory_test.go
@@ -1,12 +1,12 @@
 package store_test
 
 import (
-	. "github.com/cloudfoundry/config-server/store"
+	. "code.cloudfoundry.org/config-server/store"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/cloudfoundry/config-server/config"
+	"code.cloudfoundry.org/config-server/config"
 )
 
 var _ = Describe("CreateStore", func() {

--- a/src/config-server/store/store_memory_test.go
+++ b/src/config-server/store/store_memory_test.go
@@ -1,7 +1,7 @@
 package store_test
 
 import (
-	. "github.com/cloudfoundry/config-server/store"
+	. "code.cloudfoundry.org/config-server/store"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/store/store_mysql_test.go
+++ b/src/config-server/store/store_mysql_test.go
@@ -1,12 +1,12 @@
 package store_test
 
 import (
-	. "github.com/cloudfoundry/config-server/store"
+	. "code.cloudfoundry.org/config-server/store"
 
 	"database/sql"
 	"errors"
 
-	fakes "github.com/cloudfoundry/config-server/store/storefakes"
+	fakes "code.cloudfoundry.org/config-server/store/storefakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/store/store_postgres_test.go
+++ b/src/config-server/store/store_postgres_test.go
@@ -1,12 +1,12 @@
 package store_test
 
 import (
-	. "github.com/cloudfoundry/config-server/store"
+	. "code.cloudfoundry.org/config-server/store"
 
 	"database/sql"
 	"errors"
 
-	fakes "github.com/cloudfoundry/config-server/store/storefakes"
+	fakes "code.cloudfoundry.org/config-server/store/storefakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/store/storefakes/fake_db_provider.go
+++ b/src/config-server/store/storefakes/fake_db_provider.go
@@ -4,7 +4,7 @@ package storefakes
 import (
 	"sync"
 
-	"github.com/cloudfoundry/config-server/store"
+	"code.cloudfoundry.org/config-server/store"
 )
 
 type FakeDbProvider struct {

--- a/src/config-server/store/storefakes/fake_idb.go
+++ b/src/config-server/store/storefakes/fake_idb.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"sync"
 
-	"github.com/cloudfoundry/config-server/store"
+	"code.cloudfoundry.org/config-server/store"
 )
 
 type FakeIDb struct {

--- a/src/config-server/store/storefakes/fake_irow.go
+++ b/src/config-server/store/storefakes/fake_irow.go
@@ -4,7 +4,7 @@ package storefakes
 import (
 	"sync"
 
-	"github.com/cloudfoundry/config-server/store"
+	"code.cloudfoundry.org/config-server/store"
 )
 
 type FakeIRow struct {

--- a/src/config-server/store/storefakes/fake_irows.go
+++ b/src/config-server/store/storefakes/fake_irows.go
@@ -4,7 +4,7 @@ package storefakes
 import (
 	"sync"
 
-	"github.com/cloudfoundry/config-server/store"
+	"code.cloudfoundry.org/config-server/store"
 )
 
 type FakeIRows struct {

--- a/src/config-server/store/storefakes/fake_isql.go
+++ b/src/config-server/store/storefakes/fake_isql.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/BurntSushi/migration"
-	"github.com/cloudfoundry/config-server/store"
+	"code.cloudfoundry.org/config-server/store"
 )
 
 type FakeISql struct {

--- a/src/config-server/store/storefakes/fake_store.go
+++ b/src/config-server/store/storefakes/fake_store.go
@@ -4,7 +4,7 @@ package storefakes
 import (
 	"sync"
 
-	"github.com/cloudfoundry/config-server/store"
+	"code.cloudfoundry.org/config-server/store"
 )
 
 type FakeStore struct {

--- a/src/config-server/types/certificate_generator_test.go
+++ b/src/config-server/types/certificate_generator_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/cloudfoundry/config-server/types"
+	. "code.cloudfoundry.org/config-server/types"
 
-	"github.com/cloudfoundry/config-server/types/typesfakes"
+	"code.cloudfoundry.org/config-server/types/typesfakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/types/password_generator_test.go
+++ b/src/config-server/types/password_generator_test.go
@@ -1,7 +1,7 @@
 package types_test
 
 import (
-	. "github.com/cloudfoundry/config-server/types"
+	. "code.cloudfoundry.org/config-server/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/config-server/types/rsa_key_generator_test.go
+++ b/src/config-server/types/rsa_key_generator_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 
-	. "github.com/cloudfoundry/config-server/types"
+	. "code.cloudfoundry.org/config-server/types"
 )
 
 var _ = Describe("RSAKeyGenerator", func() {

--- a/src/config-server/types/ssh_key_generator_test.go
+++ b/src/config-server/types/ssh_key_generator_test.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
 
-	. "github.com/cloudfoundry/config-server/types"
+	. "code.cloudfoundry.org/config-server/types"
 )
 
 var _ = Describe("SSHKeyGenerator", func() {

--- a/src/config-server/types/typesfakes/fake_certs_loader.go
+++ b/src/config-server/types/typesfakes/fake_certs_loader.go
@@ -6,7 +6,7 @@ import (
 	"crypto/x509"
 	"sync"
 
-	"github.com/cloudfoundry/config-server/types"
+	"code.cloudfoundry.org/config-server/types"
 )
 
 type FakeCertsLoader struct {

--- a/src/config-server/types/typesfakes/fake_value_generator.go
+++ b/src/config-server/types/typesfakes/fake_value_generator.go
@@ -4,7 +4,7 @@ package typesfakes
 import (
 	"sync"
 
-	"github.com/cloudfoundry/config-server/types"
+	"code.cloudfoundry.org/config-server/types"
 )
 
 type FakeValueGenerator struct {

--- a/src/config-server/types/typesfakes/fake_value_generator_factory.go
+++ b/src/config-server/types/typesfakes/fake_value_generator_factory.go
@@ -4,7 +4,7 @@ package typesfakes
 import (
 	"sync"
 
-	"github.com/cloudfoundry/config-server/types"
+	"code.cloudfoundry.org/config-server/types"
 )
 
 type FakeValueGeneratorFactory struct {

--- a/src/config-server/types/value_generator_factory_concrete_test.go
+++ b/src/config-server/types/value_generator_factory_concrete_test.go
@@ -1,8 +1,8 @@
 package types_test
 
 import (
-	. "github.com/cloudfoundry/config-server/types"
-	"github.com/cloudfoundry/config-server/types/typesfakes"
+	. "code.cloudfoundry.org/config-server/types"
+	"code.cloudfoundry.org/config-server/types/typesfakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
> [!WARNING]
> **Blocked** — do not merge until cloudfoundry/go-fetcher has been redeployed
> `code.cloudfoundry.org/config-server` should resolve to 
> => `github.com/cloudfoundry/config-server-release/tree/main/src/config-server`

## What

Rename the module from `github.com/cloudfoundry/config-server` (whose standalone repo is archived) to `code.cloudfoundry.org/config-server`, updating all internal import paths and the integration `gexec.Build` target. Pure import-path change — no behavioral change.

## Why

`code.cloudfoundry.org/config-server` is the canonical vanity import path. Because the module now lives at `src/config-server` within this repository (below the repo root), resolving that short path requires go-fetcher to emit the optional fourth `subdir` field of the `go-import` meta tag, which the go command recognizes as of **Go 1.25**.

## Dependencies

- cloudfoundry/go-fetcher#5 — adds the `Subdirs` config + emits the `go-import` subdir field (**the blocker named above**).
- cloudfoundry/go-fetcher#11 — routes `config-server` to this repo (`Overrides` + `Subdirs` entry). Must also be merged and deployed for `go get code.cloudfoundry.org/config-server` to resolve.

## Verification

- `bin/lint` — 0 issues
- `bin/test-unit` — all unit suites pass
- `bin/test-integration memory` — 33/33 pass

## Consumer notes

- Consumers need **Go 1.25+** to understand the subdir field.
- Tagged releases must use tags prefixed with the subdirectory, e.g. `src/config-server/vX.Y.Z`.